### PR TITLE
Link to `libmpv.so` instead of `libmpv.so.1`

### DIFF
--- a/.github/workflows/build-all-ci.yml
+++ b/.github/workflows/build-all-ci.yml
@@ -56,7 +56,14 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          DEBIAN_FRONTEND=noninteractive sudo apt-get -y install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync libayatana-appindicator3-dev libmpv-dev mpv
+          DEBIAN_FRONTEND=noninteractive sudo apt-get -y install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync libayatana-appindicator3-dev libmpv-dev
+      - name: Trim unused dependencies
+        shell: bash
+        run: |
+          sudo rm /usr/lib/x86_64-linux-gnu/libmpv.so
+          sudo rm /usr/lib/x86_64-linux-gnu/libmpv.so.1
+          sudo mv /usr/lib/x86_64-linux-gnu/libmpv.so.1.109.0 /usr/lib/x86_64-linux-gnu/libmpv.so
+          sudo patchelf --set-soname libmpv.so /usr/lib/x86_64-linux-gnu/libmpv.so
       - name: Install flutter
         shell: bash
         run: |
@@ -166,7 +173,14 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          DEBIAN_FRONTEND=noninteractive sudo apt-get -y install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync libayatana-appindicator3-dev libmpv-dev mpv
+          DEBIAN_FRONTEND=noninteractive sudo apt-get -y install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev binutils coreutils desktop-file-utils fakeroot fuse libgdk-pixbuf2.0-dev patchelf python3-pip python3-setuptools squashfs-tools strace util-linux zsync libayatana-appindicator3-dev libmpv-dev
+      - name: Trim unused dependencies
+        shell: bash
+        run: |
+          sudo rm /usr/lib/aarch64-linux-gnu/libmpv.so
+          sudo rm /usr/lib/aarch64-linux-gnu/libmpv.so.1
+          sudo mv /usr/lib/aarch64-linux-gnu/libmpv.so.1.109.0 /usr/lib/aarch64-linux-gnu/libmpv.so
+          sudo patchelf --set-soname libmpv.so /usr/lib/aarch64-linux-gnu/libmpv.so
       - name: Install flutter
         shell: bash
         run: |

--- a/DOWNLOADS.md
+++ b/DOWNLOADS.md
@@ -84,6 +84,13 @@ For instructions on how to easily set up Passy using Ubuntu/Debian software app 
 
 It's most comfortable to run AppImages with the [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher/releases/latest) installed. It automatically integrates AppImages and their `.desktop` files into your program launcher for best user experience.
 
+You will need to install several extra packages required to run Passy: `libayatana-appindicator3-1 libmpv-dev`.  
+On Ubuntu/Debian Linux, you can install them using apt:
+```bash
+sudo apt install -y libayatana-appindicator3-1 libmpv-dev
+```
+
+After installing the required packages, you can run Passy as follows:
 1. Download the archive from [latest release](https://github.com/GlitterWare/Passy/releases/latest). AppImage archives are named in format `Passy-<version>-Linux-AppImage.zip`.
 2. Extract the `.AppImage` file to desired installation location.
 3. Run the `.AppImage` as a program.
@@ -96,6 +103,13 @@ It's most comfortable to run AppImages with the [AppImageLauncher](https://githu
 
 ### Bundle
 
+You will need to install several extra packages required to run Passy: `libayatana-appindicator3-1 libmpv-dev`.  
+On Ubuntu/Debian Linux, you can install them using apt:
+```bash
+sudo apt install -y libayatana-appindicator3-1 libmpv-dev
+```
+
+After installing the required packages, you can run Passy as follows:
 1. Download the archive from [latest release](https://github.com/GlitterWare/Passy/releases/latest). Linux bundle archives are named in format `Passy-<version>-Linux-Bundle.zip`.
 2. Extract the archive to desired installation location.
 3. Run `passy` inside the extracted folder to launch the app.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ For instructions on how to easily set up Passy using Ubuntu/Debian software app 
 
 It's most comfortable to run AppImages with the [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher/releases/latest) installed. It automatically integrates AppImages and their `.desktop` files into your program launcher for best user experience.
 
+You will need to install several extra packages required to run Passy: `libayatana-appindicator3-1 libmpv-dev`.  
+On Ubuntu/Debian Linux, you can install them using apt:
+```bash
+sudo apt install -y libayatana-appindicator3-1 libmpv-dev
+```
+
+After installing the required packages, you can run Passy as follows:
 1. Download the archive from [latest release](https://github.com/GlitterWare/Passy/releases/latest). AppImage archives are named in format `Passy-<version>-Linux-AppImage.zip`.
 2. Extract the `.AppImage` file to desired installation location.
 3. Run the `.AppImage` as a program.
@@ -163,6 +170,13 @@ It's most comfortable to run AppImages with the [AppImageLauncher](https://githu
 
 ### Bundle
 
+You will need to install several extra packages required to run Passy: `libayatana-appindicator3-1 libmpv-dev`.  
+On Ubuntu/Debian Linux, you can install them using apt:
+```bash
+sudo apt install -y libayatana-appindicator3-1 libmpv-dev
+```
+
+After installing the required packages, you can run Passy as follows:
 1. Download the archive from [latest release](https://github.com/GlitterWare/Passy/releases/latest). Linux bundle archives are named in format `Passy-<version>-Linux-Bundle.zip`.
 2. Extract the archive to desired installation location.
 3. Run `passy` inside the extracted folder to launch the app.
@@ -223,10 +237,10 @@ Passy is open-source, feel free to make modifications to it and build it yoursel
 2. Clone the repository or [get the source code from the latest Passy release](https://github.com/GlitterWare/Passy/releases/latest).
 3. Run `flutter build [subcommand]` to build passy for your system. Passy can be built to `windows`, `linux`, `apk` and `aab`.
 
-If you are building for Linux, you will need to install several extra packages required to build Passy's GUI features: `libayatana-appindicator3-dev libmpv-dev mpv`.  
+If you are building for Linux, you will need to install several extra packages required to build Passy's GUI features: `libayatana-appindicator3-dev libmpv-dev`.  
 On Ubuntu/Debian Linux, you can install them using apt:
 ```bash
-sudo apt install -y libayatana-appindicator3-dev libmpv-dev mpv
+sudo apt install -y libayatana-appindicator3-dev libmpv-dev
 ```
 
 ### Build Options

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -80,7 +80,11 @@ class MyHttpOverrides extends HttpOverrides {
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   try {
-    MediaKit.ensureInitialized();
+    if (Platform.isLinux) {
+      MediaKit.ensureInitialized(libmpv: 'libmpv.so');
+    } else {
+      MediaKit.ensureInitialized();
+    }
   } catch (e) {
     // ignore: avoid_print
     print('E:`MediaKit.ensureInitialized()` failed: $e');

--- a/lib/passy_data/common.dart
+++ b/lib/passy_data/common.dart
@@ -18,7 +18,7 @@ import 'dart:io';
 import 'glare/glare_client.dart';
 import 'key_derivation_type.dart';
 
-const String passyVersion = '1.9.2';
+const String passyVersion = '1.9.3';
 const String syncVersion = '2.2.0';
 const String accountVersion = '2.5.0';
 

--- a/linux_assets/com.glitterware.passy.appdata.xml
+++ b/linux_assets/com.glitterware.passy.appdata.xml
@@ -60,7 +60,7 @@
 	</provides>
 	<content_rating type="oars-1.0" />
 	<releases>
-		<release version="v1.9.2" date="2025-02-22">
+		<release version="v1.9.3" date="2025-02-23">
 		</release>
 	</releases>
 </component>

--- a/passy.iss
+++ b/passy.iss
@@ -3,7 +3,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName      "Passy"
-#define MyAppVersion   "1.9.2"
+#define MyAppVersion   "1.9.3"
 #define MyAppPublisher "GlitterWare"
 #define MyAppURL       "https://glitterware.github.io/Passy"
 #define MyAppExeName   "passy.exe"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.9.2+22
+version: 1.9.3+23
 
 environment:
   sdk: ">=3.4.1 <4.0.0"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: passy
 base: core22
-version: 'v1.9.2'
+version: 'v1.9.3'
 summary: Offline password manager with cross-platform synchronization # 79 char long summary
 description: |
   Store passwords, payment cards notes, ID cards and identities offline and safe, synchronized between all of your devices.


### PR DESCRIPTION
This is a hotfix for Linux users missing the `libmpv1` library in their package manager.

You will need to install several extra packages required to run v1.9.* versions of Passy: `libayatana-appindicator3-1 libmpv-dev`.  
On Ubuntu/Debian Linux, you can install them using apt:
```bash
sudo apt install -y libayatana-appindicator3-1 libmpv-dev
```

The downloads webpage (https://glitterware.github.io/Passy/#/downloads) will soon be updated to include this information.

Changes:
- Linking to `libmpv.so` instead of `libmpv.so.1` - compatibility with `libmpv1` dropped in favor of `libmpv-dev`, which is available on more package repositories.